### PR TITLE
Update Miniconda3 Image from 4.12 to 23.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:4.12.0
+FROM continuumio/miniconda3:23.10.0-1
 # FROM mambaorg/micromamba:1.3.1
 
 


### PR DESCRIPTION
I was running into some weird issues with shared object files. 

![image](https://github.com/tethysapp/conda-package-publish-action/assets/153777116/220165f1-4d97-4de5-b739-239aafdad2ed)

I noticed that there were lots of prompts to upgrade the conda version. After updating the miniconda3 image, the issue was resolved and my build worked again.

